### PR TITLE
Special Weaselstation Soda crate

### DIFF
--- a/Resources/Prototypes/_Weaselstation/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/_Weaselstation/Catalog/Cargo/cargo_food.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: SpeacialSodaCrate  ##For Weaselstation
+  icon:
+    sprite: _Weaselstation/Objects/Consumable/Drinks/weh_max.rsi
+    state: icon
+  product: WeaselstationSodaSupply
+  cost: 225
+  category: cargoproduct-category-name-food
+  group: market

--- a/Resources/Prototypes/_Weaselstation/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/_Weaselstation/Catalog/Fills/Crates/food.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: WeaselstationSodaSupply
+  parent: CratePlastic
+  name: Special Soda Supply
+  description: Drinks specifically concocted to bring you joy!
+  components:
+  - type: StorageFill
+    contents:
+    - id: DrinkWehMaxCan
+      amount: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Crack open a cold "weh" with all you friends now by ordering the "special soda crate" from cargo!

## Why / Balance
fun

## Technical details
N/A

##Media
![Screenshot 2024-10-04 180806](https://github.com/user-attachments/assets/10fd62e8-a80b-4a11-9055-87331475e2f0)
![Screenshot 2024-10-04 180343](https://github.com/user-attachments/assets/9b6545ac-7e27-4f03-9735-cbe6c86ef837)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

:cl:
- add: Added special soda crate.
- add: Added ability to order special soda crate from cargo.
